### PR TITLE
[NH CS] Add -id to mailer keyword

### DIFF
--- a/src/clj/turbovote/imbarcode.clj
+++ b/src/clj/turbovote/imbarcode.clj
@@ -63,7 +63,7 @@
       (assoc response :customer-number (subs imb 5 20))
       (let [mailer-and-serial (subs imb 5 20)]
         (assoc response
-          :6-digit-mailer {:mailer (subs mailer-and-serial 0 6)
+          :6-digit-mailer {:mailer-id (subs mailer-and-serial 0 6)
                            :serial-number (subs mailer-and-serial 6)}
-          :9-digit-mailer {:mailer (subs mailer-and-serial 0 9)
+          :9-digit-mailer {:mailer-id (subs mailer-and-serial 0 9)
                            :serial-number (subs mailer-and-serial 9)})))))

--- a/test/cljx/turbovote/imbarcode_test.cljx
+++ b/test/cljx/turbovote/imbarcode_test.cljx
@@ -42,7 +42,7 @@
           result (split-structure-digits structure-digits)]
       (is (= barcode (:barcode result)))
       (is (= service (:service result)))
-      (is (= mailer (get-in result [:6-digit-mailer :mailer])))
+      (is (= mailer (get-in result [:6-digit-mailer :mailer-id])))
       (is (= serial (get-in result [:6-digit-mailer :serial-number])))
       (is (= routing (:routing result)))))
   (testing "origin"


### PR DESCRIPTION
Change :mailer to :mailer-id in returned map.
