### PR TITLE
Add encodable? predicate fn

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+## Changes between 1.0.0 and HEAD
+
+* Added a new `imbarcode.core/encodable?` predicate fn that takes all the same
+  arguments (including the 3 different arities) as `imbarcode.core/encode` and
+  returns true if they can be encoded into an IMb or false otherwise. This is
+  much faster than doing the actual encoding if all you're interested in is
+  whether or not you have enough / valid input data to encode an IMb.
+
 ## Changes between 0.1.6 and 1.0.0
 
 * Project renamed from `turbovote.imbarcode` to `democracyworks/imbarcode`

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.89"]]
+                 [org.clojure/clojurescript "1.9.229"]
+                 [org.clojure/test.check "0.9.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-doo "0.1.7"]]
   :profiles {:dev {:dependencies [[doo "0.1.7"]

--- a/src/cljc/imbarcode/crc.cljc
+++ b/src/cljc/imbarcode/crc.cljc
@@ -33,7 +33,6 @@
             :else
             (recur (xor result poly-div))))))
 
-
 (defn IMb-fcs
   "Returns the 11 bit IMb frame check sequence
    represented as a vector of 0s and 1s.

--- a/test/cljc/imbarcode/core_test.cljc
+++ b/test/cljc/imbarcode/core_test.cljc
@@ -69,10 +69,10 @@
 
 (def gen-structure-digits
   (gen/fmap #(apply str %)
-   (gen/tuple barcode
-              (gen/fmap #(apply str %)
-                        (gen/vector (gen/choose 0 9) 18))
-              routing-code)))
+            (gen/tuple barcode
+                       (gen/fmap #(apply str %)
+                                 (gen/vector (gen/choose 0 9) 18))
+                       routing-code)))
 
 (defspec encode-spec 1000
   (prop/for-all [structure-digits gen-structure-digits]

--- a/test/cljc/imbarcode/core_test.cljc
+++ b/test/cljc/imbarcode/core_test.cljc
@@ -1,5 +1,6 @@
 (ns imbarcode.core-test
   (:require [imbarcode.core :refer [encode
+                                    encodable?
                                     barcode-id:default
                                     service-type-id:origin
                                     split-structure-digits
@@ -76,6 +77,8 @@
 
 (defspec encode-spec 1000
   (prop/for-all [structure-digits gen-structure-digits]
+    (and
+     (encodable? structure-digits)
      (let [encoded (encode structure-digits)]
        (and encoded
             (every? #{\A \D \F \T} encoded))))))

--- a/test/cljc/imbarcode/core_test.cljc
+++ b/test/cljc/imbarcode/core_test.cljc
@@ -76,11 +76,9 @@
 
 (defspec encode-spec 1000
   (prop/for-all [structure-digits gen-structure-digits]
-    (and
-     (encodable? structure-digits)
-     (let [encoded (encode structure-digits)]
-       (and encoded
-            (every? #{\A \D \F \T} encoded))))))
+    (let [encoded (encode structure-digits)]
+      (and encoded
+           (every? #{\A \D \F \T} encoded)))))
 
 (deftest split-structure-digits-test
   (testing "destination"

--- a/test/cljc/imbarcode/core_test.cljc
+++ b/test/cljc/imbarcode/core_test.cljc
@@ -68,8 +68,7 @@
                        (gen/choose 0 4))))
 
 (def gen-structure-digits
-  (gen/fmap (fn [[bc base routing]]
-              (str bc base routing))
+  (gen/fmap #(apply str %)
    (gen/tuple barcode
               (gen/fmap #(apply str %)
                         (gen/vector (gen/choose 0 9) 18))

--- a/test/cljc/imbarcode/core_test.cljc
+++ b/test/cljc/imbarcode/core_test.cljc
@@ -78,7 +78,8 @@
   (prop/for-all [structure-digits gen-structure-digits]
     (let [encoded (encode structure-digits)]
       (and encoded
-           (every? #{\A \D \F \T} encoded)))))
+           (every? #{\A \D \F \T} encoded)
+           (= 65 (count encoded))))))
 
 (deftest split-structure-digits-test
   (testing "destination"


### PR DESCRIPTION
In Ballot Scout we were encoding IMbs to determine if a mailing was trackable or not, but that's an expensive enough operation that it was really slowing down our stats calculations for hundreds of thousands of mailings (a county in Utah was taking 4 minutes for `/stats` to respond).

So I wrote some `test.check` tests that attempt to make sure there aren't IMb structure digit strings that make it past the `core/encode` pre-assertions but still fail to encode for some reason. Once it looked like that wasn't the case, I extracted the pre-assertions into a new `core/encodable?` fn and used that as the new pre-assertion in every arity of `core/encode`. That then allows me to use `encodable?` (which is _much_ faster than `encode`) in Ballot Scout to determine if a mailing will be trackable or not. The aforementioned Utah county now gets `/stats` results in ~40 seconds.

This all seem OK to you, dear reviewer? If so, what else should the `encode-spec` be checking for?