### PR TITLE
Add new service type IDs for ballot mail

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,5 @@
+## Changes between 1.0.2 and HEAD
+
 ## Changes between 1.0.1 and 1.0.2
 
 * Added service type IDs for ballot mail origin tracing: `777`, `778`, `779`.

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,4 @@
-## Changes between 1.0.1 and HEAD
+## Changes between 1.0.1 and 1.0.2
 
 * Added service type IDs for ballot mail origin tracing: `777`, `778`, `779`.
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## Changes between 1.0.1 and HEAD
+
+* Added service type IDs for ballot mail origin tracing: `777`, `778`, `779`.
+
 ## Changes between 1.0.0 and 1.0.1
 
 * Added a new `imbarcode.core/encodable?` predicate fn that takes all the same

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject democracyworks/imbarcode "1.0.2-SNAPSHOT"
+(defproject democracyworks/imbarcode "1.0.2"
   :description "Generate USPS Intelligent Mail Barcodes"
   :url "https://github.com/democracyworks/imbarcode"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject democracyworks/imbarcode "1.0.2"
+(defproject democracyworks/imbarcode "1.0.3-SNAPSHOT"
   :description "Generate USPS Intelligent Mail Barcodes"
   :url "https://github.com/democracyworks/imbarcode"
   :license {:name "Eclipse Public License"

--- a/src/cljc/imbarcode/core.cljc
+++ b/src/cljc/imbarcode/core.cljc
@@ -18,7 +18,11 @@
 (def ^:export service-type-id:destination "040")
 (def ^:export service-type-id:origin "050")
 
-(def origin-service-types #{"050" "051" "052"})
+(def origin-service-types
+  "The service type IDs that allow our system to classify an IMb as
+  partner-bound (aka \"origin tracing\")."
+  #{"050" "051" "052"
+    "777" "778" "779"})
 
 (defn ^:export split-structure-digits
   "Split IMbarcode structure digits into their constituent parts"


### PR DESCRIPTION
Adds three new service type IDs to enable return tracking (aka origin IMb tracing or "partner-bound").

We are also allowing for a 1.0.2 release to get this into Ballot Scout and anywhere else `imbarcode` is used, which will be cut when this PR is approved.

References
==========

[Pivotal card](https://www.pivotaltracker.com/story/show/159899158)